### PR TITLE
Merge remote-tracking branch 'upstream/master'

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compile 'com.google.dagger:dagger:2.0.2'
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
+    provided 'javax.annotation:jsr250-api:1.0'
 
     compile 'com.jakewharton:butterknife:7.0.1'
     compile 'com.jakewharton.timber:timber:4.1.0'

--- a/app/src/main/java/frogermcs/io/githubclient/GithubClientApplication.java
+++ b/app/src/main/java/frogermcs/io/githubclient/GithubClientApplication.java
@@ -2,7 +2,6 @@ package frogermcs.io.githubclient;
 
 import android.app.Application;
 import android.content.Context;
-import android.support.annotation.VisibleForTesting;
 
 import frogermcs.io.githubclient.data.UserComponent;
 import frogermcs.io.githubclient.data.api.UserModule;
@@ -12,8 +11,7 @@ import timber.log.Timber;
 /**
  * Created by Miroslaw Stanek on 22.04.15.
  */
-    public class GithubClientApplication extends Application {
-
+public class GithubClientApplication extends Application {
     private AppComponent appComponent;
     private UserComponent userComponent;
 

--- a/app/src/main/java/frogermcs/io/githubclient/ui/activity/presenter/SplashActivityPresenter.java
+++ b/app/src/main/java/frogermcs/io/githubclient/ui/activity/presenter/SplashActivityPresenter.java
@@ -1,5 +1,7 @@
 package frogermcs.io.githubclient.ui.activity.presenter;
 
+import android.os.Handler;
+
 import frogermcs.io.githubclient.HeavyLibraryWrapper;
 import frogermcs.io.githubclient.data.api.UserManager;
 import frogermcs.io.githubclient.data.model.User;
@@ -13,23 +15,22 @@ import frogermcs.io.githubclient.utils.Validator;
 public class SplashActivityPresenter {
     public String username;
 
-    private SplashActivity splashActivity;
-    private Validator validator;
-    private UserManager userManager;
-    private HeavyLibraryWrapper heavyLibraryWrapper;
+    private final SplashActivity splashActivity;
+    private final Validator validator;
+    private final UserManager userManager;
 
     public SplashActivityPresenter(SplashActivity splashActivity, Validator validator,
                                    UserManager userManager, HeavyLibraryWrapper heavyLibraryWrapper) {
         this.splashActivity = splashActivity;
         this.validator = validator;
         this.userManager = userManager;
-        this.heavyLibraryWrapper = heavyLibraryWrapper;
 
+        HeavyLibraryWrapper heavyLibraryWrapper1 = heavyLibraryWrapper;
         //This calls should be delivered to ExternalLibrary right after it will be initialized
-        this.heavyLibraryWrapper.callMethod();
-        this.heavyLibraryWrapper.callMethod();
-        this.heavyLibraryWrapper.callMethod();
-        this.heavyLibraryWrapper.callMethod();
+        heavyLibraryWrapper1.callMethod();
+        heavyLibraryWrapper1.callMethod();
+        heavyLibraryWrapper1.callMethod();
+        heavyLibraryWrapper1.callMethod();
     }
 
     public void onShowRepositoriesClick() {
@@ -38,7 +39,13 @@ public class SplashActivityPresenter {
             userManager.getUser(username).subscribe(new SimpleObserver<User>() {
                 @Override
                 public void onNext(User user) {
-                    splashActivity.showLoading(false);
+                    // To avoid prematurely hiding the progressbar, post delayed
+                    Handler handler = new Handler();
+                    handler.postDelayed(new Runnable() {
+                        @Override public void run() {
+                            splashActivity.showLoading(false);
+                        }
+                    }, 1000 /* 1 sec */);
                     splashActivity.showRepositoriesListForUser(user);
                 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha6'
+        classpath 'com.android.tools.build:gradle:2.0.0-alpha9'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }


### PR DESCRIPTION
There was an issue in SplashActivityPresenter where it was calling `splashActivity.showLoading(false);` upon button press, and this would cause an ugly occurrence in the emulator with the spinner being hidden before transitioning to RepositoriesListActivity.  See screen capture: https://www.youtube.com/watch?v=lEo4y2RCUP8&feature=youtu.be
I fixed it by using a Handler with delay.
