### PR TITLE
Removed provideAnalyticsManager

### DIFF
--- a/app/src/main/java/frogermcs/io/githubclient/AppModule.java
+++ b/app/src/main/java/frogermcs/io/githubclient/AppModule.java
@@ -28,12 +28,6 @@ public class AppModule {
 
     @Provides
     @Singleton
-    AnalyticsManager provideAnalyticsManager() {
-        return new AnalyticsManager(application);
-    }
-
-    @Provides
-    @Singleton
     Validator provideValidator() {
         return new Validator();
     }


### PR DESCRIPTION
Don't need to provide AnalyticsManager in AppModule because AnalyticsManager constructor has only on argument which is Application and Application is already getting provided.